### PR TITLE
refactor: rename taskList field in TaskList.java to tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ application {
 }
 
 shadowJar {
-    archiveBaseName = "donezo"
+    archiveBaseName = "donezoCLI"
     archiveClassifier = null
 }
 

--- a/src/main/java/donezo/TaskList.java
+++ b/src/main/java/donezo/TaskList.java
@@ -10,38 +10,38 @@ import donezo.tasks.Task;
  * It also allows for obtaining the total number of tasks in the list.
  */
 public class TaskList {
-    private ArrayList<Task> taskList;
+    private ArrayList<Task> tasks;
 
-    public TaskList(ArrayList<Task> taskList) {
-        this.taskList = taskList;
+    public TaskList(ArrayList<Task> tasks) {
+        this.tasks = tasks;
     }
 
     public TaskList() {
-        this.taskList = new ArrayList<Task>();
+        this.tasks = new ArrayList<Task>();
     }
 
-    public ArrayList<Task> getTaskList() {
-        return taskList;
+    public ArrayList<Task> getTasks() {
+        return tasks;
     }
 
     public int getSizeTaskList() {
-        return taskList.size();
+        return tasks.size();
     }
 
     public Task getTask(int ndx) {
-        return taskList.get(ndx);
+        return tasks.get(ndx);
     }
 
     public void addTask(Task task) {
-        taskList.add(task);
+        tasks.add(task);
     }
 
     public void removeTask(int ndx) {
-        taskList.remove(ndx);
+        tasks.remove(ndx);
     }
 
     public boolean isEmpty() {
-        return taskList.isEmpty();
+        return tasks.isEmpty();
     }
 
     /**
@@ -57,7 +57,7 @@ public class TaskList {
      */
     public TaskList findMatchingTasks(String searchTerm) {
         TaskList matchingTasks = new TaskList();
-        for (Task task : taskList) {
+        for (Task task : tasks) {
             if (task.getDescription().toLowerCase().contains(searchTerm.toLowerCase())) {
                 matchingTasks.addTask(task);
             }

--- a/src/test/java/donezo/parser/ParserStorageTest.java
+++ b/src/test/java/donezo/parser/ParserStorageTest.java
@@ -22,7 +22,7 @@ public class ParserStorageTest {
         ParserStorage.parseToDo(input, storage);
 
         TaskList taskList = storage.getTaskList();
-        ArrayList<Task> tasks = taskList.getTaskList();
+        ArrayList<Task> tasks = taskList.getTasks();
 
         assertEquals(1, tasks.size());
         assertInstanceOf(Todo.class, tasks.get(0));


### PR DESCRIPTION
Currently, the field taskList in taskList.java is used to represent an ArrayList of tasks

Rename the private field "taskList" to "tasks" throughout the codebase to improve clarity and consistency, as well as to follow the specified coding guidelines for the course

This refactoring does not change any functionality, only the naming to better reflect the variable's purpose.